### PR TITLE
midi2ymzのビルドが通らなかったのを修正

### DIFF
--- a/Lab/Electronics/Misc/YMZ294/index.md
+++ b/Lab/Electronics/Misc/YMZ294/index.md
@@ -84,9 +84,11 @@ title: ヤマハ製の音源 IC YMZ294 を使ってみた
    - `cd`
    - `git clone https://github.com/kanade-k-1228/midifile.git`
    - `cd midifile`
+   - `make library`
+   - `make programs`
    - `make midi2ymz`
    - して、プログラムをビルドしてください
-   - `~/midifile ???.mid > ???.h` で変換します（`???` は自分で作った midi ファイル名を入れる）
+   - `bin/midi2ymz ???.mid > ???.h` で変換します（`???` は自分で作った midi ファイル名を入れる）
 3. include して書き込む
    - `???.h` を `sample/07_play_music` 内に移動します
    - `07_play_music.ino` の先頭の `#include "XXX.h"` を `#include "???.h"` に書き換えます


### PR DESCRIPTION
かなでさん、いつもお世話になっています！！！

midi2ymz のビルドに関して、ドキュメントに不整合がある感じだったので修正しました。
動作環境: Windows11 (WSL2, Ubuntu) で無事に動くことを確認しました。